### PR TITLE
adding interface to add data store configs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets" : ["stage-0"]
+}

--- a/common/models/config.js
+++ b/common/models/config.js
@@ -1,3 +1,0 @@
-module.exports = function(Config) {
-
-};

--- a/common/models/dataStore.js
+++ b/common/models/dataStore.js
@@ -1,0 +1,3 @@
+module.exports = function(DataStore) {
+
+};

--- a/common/models/dataStore.json
+++ b/common/models/dataStore.json
@@ -1,6 +1,6 @@
 {
-  "name": "Config",
-  "plural": "configs",
+  "name": "DataStore",
+  "plural": "stores",
   "base": "PersistedModel",
   "idInjection": true,
   "options": {
@@ -24,8 +24,7 @@
       "required": true
     },
     "uri": {
-      "type": "string",
-      "required": true
+      "type": "string"
     }
   },
   "validations": [],

--- a/server/boot/create-routes.js
+++ b/server/boot/create-routes.js
@@ -3,7 +3,7 @@ var express = require('express');
 var webpack = require('webpack');
 var webpackDevMiddleware = require('webpack-dev-middleware');
 var webpackHotMiddleware = require('webpack-hot-middleware');
-var config = require('../../client/webpack.config');
+var config = require('../../web/webpack.config');
 
 module.exports = function(app) {
   // configure hot reloading for development
@@ -12,18 +12,18 @@ module.exports = function(app) {
   app.use(webpackHotMiddleware(compiler));
 
   // configure routes
-  app.use('/static', express.static(path.join(__dirname, '../../client/dist')));
+  app.use('/static', express.static(path.join(__dirname, '../../web/dist')));
 
   app.get('/status', function(req, res) {
     res.send(app.loopback.status());
   });
 
   app.get('/', function(req, res) {
-    res.sendFile(path.join(__dirname, '../../client/index.html'));
+    res.sendFile(path.join(__dirname, '../../web/index.html'));
   });
 
   // return the index for any non-api call
   app.get(/^\/((?!api).)/, function(req, res) {
-    res.sendFile(path.join(__dirname, '../../client/index.html'));
+    res.sendFile(path.join(__dirname, '../../web/index.html'));
   });
 };

--- a/server/boot/create-tables.js
+++ b/server/boot/create-tables.js
@@ -8,8 +8,8 @@ module.exports = function(app) {
   });
 
   var pg = app.dataSources.postgres;
-  var scTables = ['Config', 'Event'];
-  pg.automigrate(scTables, function(er) {
+  var scTables = ['DataStore', 'Event'];
+  pg.autoupdate(scTables, function(er) {
     if (er) throw er;
     console.log('SpatialConnect tables [' + scTables + '] created in ', pg.adapter.name);
   });

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -32,7 +32,7 @@
     "dataSource": "db",
     "public": false
   },
-  "Config": {
+  "DataStore": {
     "dataSource": "postgres",
     "public": true,
     "$promise": {},

--- a/web/components/AddDataStore.js
+++ b/web/components/AddDataStore.js
@@ -1,0 +1,12 @@
+'use strict';
+import React, { PropTypes } from 'react';
+
+const AddDataStore = ({ onClick }) => (
+  <button onClick={onClick}>Add Data Store</button>
+);
+
+AddDataStore.propTypes = {
+  onClick: PropTypes.func.isRequired
+};
+
+export default AddDataStore;

--- a/web/components/DataStoreForm.js
+++ b/web/components/DataStoreForm.js
@@ -1,0 +1,54 @@
+'use strict';
+import React, { Component, PropTypes } from 'react';
+import { reduxForm } from 'redux-form';
+
+let DataStoreForm = (props) => {
+  const {
+    fields: { id, storeId, name, type, version },
+    handleSubmit
+  } = props;
+
+  return (
+    <form>
+      <div>
+        <label>ID:</label>
+        <span>{storeId.initialValue}</span>
+        <input
+          {...storeId}
+          type="text"
+          hidden />
+      </div>
+      <div>
+        <label>Name</label>
+        <input
+          {...name}
+          type="text"
+          placeholder="enter the name for the data store" />
+      </div>
+      <div>
+        <label>Type</label>
+        <div>
+          <select {...type}>
+            <option value="">Select a type..</option>
+            <option value="geojson">GeoJSON</option>
+            <option value="gpkg">GeoPackage</option>
+          </select>
+        </div>
+      </div>
+      <div>
+        <label>Version</label>
+        <input
+          {...version}
+          type="text"
+          placeholder="enter a version for the store's type" />
+      </div>
+    </form>
+  );
+};
+
+DataStoreForm = reduxForm({
+  form: 'dataStore',
+  fields: ['id', 'storeId', 'name', 'type', 'version']
+})(DataStoreForm);
+
+export default DataStoreForm;

--- a/web/components/DataStoreItem.js
+++ b/web/components/DataStoreItem.js
@@ -1,0 +1,19 @@
+'use strict';
+import React, { PropTypes } from 'react';
+import DataStoreForm from './DataStoreForm';
+
+const DataStoreItem = ({ dataStore, onSubmit }) => (
+  <li className="list-item">
+    <DataStoreForm
+      initialValues={dataStore}
+      formKey={dataStore.storeId}
+      onSubmit={onSubmit}/>
+  </li>
+);
+
+DataStoreItem.propTypes = {
+  dataStore: PropTypes.object.isRequired,
+  onSubmit: PropTypes.func.isRequired
+};
+
+export default DataStoreItem;

--- a/web/components/DataStoresList.js
+++ b/web/components/DataStoresList.js
@@ -1,0 +1,18 @@
+'use strict';
+import React, { PropTypes } from 'react';
+import DataStoreItem from './DataStoreItem';
+
+const DataStoresList = ({ dataStores, onSubmit }) => (
+  <ul className="list">
+    {dataStores.map(store =>
+      <DataStoreItem key={store.id} dataStore={store} onSubmit={onSubmit} />
+    )}
+  </ul>
+);
+
+DataStoresList.propTypes = {
+  dataStores: PropTypes.array.isRequired,
+  onSubmit: PropTypes.func.isRequired
+};
+
+export default DataStoresList;

--- a/web/components/EventDetails.js
+++ b/web/components/EventDetails.js
@@ -7,6 +7,7 @@ const EventDetails = (props) => {
   return (
     <div>
       <h4>EventId: {params.id}</h4>
+      {props.children}
     </div>
   );
 };

--- a/web/components/EventsList.js
+++ b/web/components/EventsList.js
@@ -12,7 +12,7 @@ const EventItem = ({ event }) => (
 
 EventItem.propTypes = {
   event: PropTypes.object.isRequired
-}
+};
 
 const EventsList = ({ eventsList }) => (
   <ul className="list">
@@ -22,6 +22,6 @@ const EventsList = ({ eventsList }) => (
 
 EventsList.propTypes = {
   eventsList: PropTypes.array.isRequired
-}
+};
 
 export default EventsList;

--- a/web/containers/DataStoresContainer.js
+++ b/web/containers/DataStoresContainer.js
@@ -1,0 +1,87 @@
+'use strict';
+import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import * as dataStoresActions from '../ducks/dataStores';
+import DataStoresList from '../components/DataStoresList';
+import AddDataStore from '../components/AddDataStore';
+import DataStoreForm from '../components/DataStoreForm';
+import { getValues } from 'redux-form';
+
+class DataStoresContainer extends Component {
+
+  loadDataStores = () => {
+    this.props.actions.loadDataStores();
+  }
+
+  componentDidMount() {
+    this.loadDataStores();
+  }
+
+  addNewDataStore = () => {
+    this.props.actions.addNewDataStoreClicked();
+  }
+
+  submitNewDataStore = (data) => {
+    this.props.actions.submitNewDataStore(data);
+  }
+
+  saveDataStores = () => {
+    // if you are currently adding a new store, the save button will only
+    // save changes to the new data store
+    if (this.props.addingNewDataStore) {
+      // trigger submit
+      this.refs.newDataStoreForm.submit();
+    }
+    else {
+      // for now, just sync the current state b/c put operations are idempotent
+      const storeIds = Object.keys(this.props.forms);
+      storeIds.map((storeId) => {
+        let values = getValues(this.props.forms[storeId]);
+        this.props.actions.updateDataStore(values.id, values);
+      });
+    }
+  }
+
+  render() {
+    const {loading, stores, addingNewDataStore, newDataStoreId} = this.props;
+    let initialValues = {storeId: newDataStoreId};
+
+    return (
+      <div className="container">
+        <section className="main">
+          {loading ? 'Fetching Data Stores...': ''}
+          {addingNewDataStore
+            ? <DataStoreForm
+                ref="newDataStoreForm"
+                initialValues={initialValues}
+                onSubmit={this.submitNewDataStore}
+                />
+            : <AddDataStore onClick={this.addNewDataStore} />}
+          <DataStoresList
+            dataStores={stores}
+            onSubmit={this.saveDataStores}
+            />
+          <button onClick={this.saveDataStores}>Save</button>
+        </section>
+      </div>
+    );
+  }
+}
+
+function mapAtomStateToProps(state) {
+  return {
+    loading: state.sc.dataStores.loading,
+    stores: state.sc.dataStores.stores,
+    addingNewDataStore: state.sc.dataStores.addingNewDataStore,
+    newDataStoreId: state.sc.dataStores.newDataStoreId,
+    forms: state.form.dataStore
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return { actions: bindActionCreators(dataStoresActions, dispatch) };
+}
+
+  // connect this "smart" container component to the redux store
+export default connect(mapAtomStateToProps, mapDispatchToProps)(DataStoresContainer);

--- a/web/ducks/dataStores.js
+++ b/web/ducks/dataStores.js
@@ -1,0 +1,128 @@
+'use strict';
+import { reset } from 'redux-form';
+import * as request from 'superagent';
+const API_URL = 'http://default:3000/api/'; // TODO: make this an env var
+ import uuid from 'node-uuid';
+
+// define action types
+export const LOAD = 'sc/dataStores/LOAD';
+export const LOAD_SUCCESS = 'sc/dataStores/LOAD_SUCCESS';
+export const LOAD_FAIL = 'sc/dataStores/LOAD_FAIL';
+export const ADD_NEW_DATA_STORE_CLICKED = 'sc/dataStores/ADD_NEW_DATA_STORE_CLICKED';
+
+// define an initialState
+const initialState = {
+  loading: false,
+  loaded: false,
+  stores: [],
+  addingNewDataStore: false,
+  newDataStoreId: null
+};
+
+// export the reducer function, (previousState, action) => newState
+export default function reducer(state = initialState, action = {}) {
+  switch (action.type) {
+    // note that we do not mutate the previous state; instead we use the object
+    // spread operator to make a more readable, succinct expression of the
+    // updated state.  For more details see:
+    // http://redux.js.org/docs/recipes/UsingObjectSpreadOperator.html
+    case LOAD:
+      return {
+        ...state,
+        loading: true,
+        addingNewDataStore: false
+      };
+    case LOAD_SUCCESS:
+      return {
+        ...state,
+        loading: false,
+        loaded: true,
+        stores: action.stores
+      };
+    case LOAD_FAIL:
+      return {
+        ...state,
+        loading: false,
+        loaded: false,
+        error: action.error
+      };
+    case ADD_NEW_DATA_STORE_CLICKED:
+      return {
+        ...state,
+        addingNewDataStore: true,
+        newDataStoreId: uuid.v4()
+      };
+    // return the previousState if no actions match
+    default: return state;
+  }
+}
+
+
+// export the action creators (functions that return actions or functions)
+export function receiveStores(stores) {
+  return {
+    type: LOAD_SUCCESS,
+    stores: stores
+  };
+}
+
+export function loadDataStores() {
+  // When action creators return functions instead of plain action objects, they
+  // are handled by the thunk middleware, which passes the dispatch method as
+  // an argument to the function
+  return dispatch => {
+
+    // disptach an action to update the state, indicating we are starting the
+    // request to load events
+    dispatch({ type: LOAD });
+
+    // async get the stores and dispatch action when they are received
+    request
+      .get(API_URL + 'stores')
+      .end(function(err, res) {
+        if (err) {
+          throw new Error(res);
+        }
+        dispatch(receiveStores(res.body));
+      });
+  }
+}
+
+export function addNewDataStoreClicked() {
+  // clear the form values
+  return dispatch => {
+    dispatch(reset('dataStore'));
+    dispatch({type: ADD_NEW_DATA_STORE_CLICKED});
+  };
+}
+
+export function submitNewDataStore(data) {
+  return dispatch => {
+    request
+      .post(API_URL + 'stores')
+      .send(data)
+      .end(function(err, res) {
+        if (err) {
+          throw new Error(res);
+        }
+        dispatch(loadDataStores());
+      });
+  };
+}
+
+export function updateDataStore(id, data) {
+  return dispatch => {
+    request
+      .put(API_URL + 'stores/' + id)
+      .send(data)
+      .end(function(err, res) {
+        if (err) {
+          throw new Error(res);
+        }
+        dispatch(loadDataStores());
+      });
+
+    // clear the form values
+    dispatch(reset('dataStore'));
+  };
+}

--- a/web/ducks/index.js
+++ b/web/ducks/index.js
@@ -1,10 +1,12 @@
 'use strict';
 import { combineReducers } from 'redux';
 import events from './events';
+import dataStores from './dataStores';
 
 // http://redux.js.org/docs/api/combineReducers.html
 const appReducer = combineReducers({
-  events
+  events,
+  dataStores
 });
 
 export default appReducer;

--- a/web/index.js
+++ b/web/index.js
@@ -9,9 +9,10 @@ import App from './components/App';
 import thunk from 'redux-thunk';
 import createLogger from 'redux-logger';
 import { reducer as formReducer } from 'redux-form';
-import { Router, Route, browserHistory } from 'react-router';
+import { Router, Route, IndexRoute, browserHistory } from 'react-router';
 import { syncHistoryWithStore, routerReducer } from 'react-router-redux';
 import EventsContainer from './containers/EventsContainer';
+import DataStoresContainer from './containers/DataStoresContainer';
 import EventDetails from './components/EventDetails';
 
 // combine all the reducers into a single reducing function
@@ -40,7 +41,9 @@ render(
     <Router history={history}>
       <Route path="/" component={App}>
         <Route path="/events" component={EventsContainer}>
-          <Route path="/events/:id" component={EventDetails} />
+          <Route path="/events/:id" component={EventDetails} >
+            <IndexRoute component={DataStoresContainer} />
+          </Route>
         </Route>
       </Route>
     </Router>

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.5.0",
+    "node-uuid": "^1.4.7",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-redux": "^4.1.2",
@@ -23,6 +24,7 @@
     "babel-loader": "^6.2.0",
     "babel-plugin-transform-class-properties": "^6.5.2",
     "babel-plugin-transform-object-rest-spread": "^6.5.0",
+    "babel-polyfill": "^6.7.2",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.5.0",
     "babel-preset-react-hmre": "^1.0.1",

--- a/web/test/dataStores.js
+++ b/web/test/dataStores.js
@@ -1,0 +1,87 @@
+'use strict';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils, { createRenderer } from 'react-addons-test-utils';
+import expect from 'expect';
+import DataStoresList from '../components/DataStoresList';
+import DataStoreItem from '../components/DataStoreItem';
+import DataStoreForm from '../components/DataStoreForm';
+
+const dataStores = [{
+  "storeId":"43ea5f5d-0e1b-40c5-80e8-c39b460a88c9",
+  "name":"a new geojson store 2",
+  "type":"geojson",
+  "version":"1.0",
+  "uri":null,
+  "id":1
+}];
+
+describe('DataStoresList', function() {
+
+  function setup(props={}) {
+      let defaultProps = {
+        dataStores: [],
+        onSubmit: () => {}
+      };
+      props = Object.assign(defaultProps, props);
+
+      // render component with shallow renering
+      // see: https://facebook.github.io/react/docs/test-utils.html#shallow-rendering
+      let renderer = TestUtils.createRenderer();
+      renderer.render(<DataStoresList {...props} />);
+      let output = renderer.getRenderOutput();
+      return {props, output};
+  }
+
+  it('should exist', function(){
+    const { output } = setup();
+    expect(output.type).toBe('ul')
+  });
+
+  it('should render 1 data store when passed 1 store in the props', () => {
+    const {output} = setup({dataStores: dataStores});
+    expect(output.props.children.length).toBe(1);
+    expect(output.props.children[0].props.dataStore).toBe(dataStores[0]);
+  });
+
+});
+
+describe('DataStoreItem', function() {
+
+  function setup(props={}) {
+      let defaultProps = {
+        dataStore: {},
+        onSubmit: () => {}
+      };
+      props = Object.assign(defaultProps, props);
+
+      // render component with shallow renering
+      // see: https://facebook.github.io/react/docs/test-utils.html#shallow-rendering
+      let renderer = TestUtils.createRenderer();
+      renderer.render(<DataStoreItem {...props} />);
+      let output = renderer.getRenderOutput();
+      return {props, output};
+  }
+
+  it('should exist', function(){
+    const { output } = setup();
+    expect(output.type).toBe('li')
+  });
+
+  it('should render 1 data store form when passed 1 store in the props', () => {
+    const {output} = setup({dataStore: dataStores[0]});
+    expect(output.props.children).toBeTruthy();
+  });
+
+  it('should setup the initialValues of the form component', () => {
+    const {output} = setup({dataStore: dataStores[0]});
+    expect(output.props.children.props.initialValues).toBe(dataStores[0]);
+  });
+
+  it('should set the formKey as the storeId', () => {
+    const {output} = setup({dataStore: dataStores[0]});
+    expect(output.props.children.props.formKey).toBe(dataStores[0].storeId);
+  });
+
+});

--- a/web/test/events.js
+++ b/web/test/events.js
@@ -42,7 +42,7 @@ describe('events async action creators', () => {
       'name': 'some name',
       'description': 'some description'
     }];
-    nock('http://localhost:3000/api/')
+    nock('http://default:3000/api/')
       .get('/events')
       .reply(200, eventsResponse);
     const expectedActions = [
@@ -59,10 +59,10 @@ describe('events async action creators', () => {
       'description': 'some description'
     };
     const eventsResponse = [ mockEvent ];
-    nock('http://localhost:3000/api/')
+    nock('http://default:3000/api/')
       .get('/events')
       .reply(200, eventsResponse);
-    nock('http://localhost:3000/api/')
+    nock('http://default:3000/api/')
       .post('/events')
       .reply(200);
     const expectedActions = [


### PR DESCRIPTION
## Status

READY
## Description

Creating the web interface for generating data store configurations for an event.  Also, renaming model `Config` to `DataStore`
- SPACON-15
## Todos
- [x] Tests
- [x] Documentation
## Deploy Notes

N/A
## Steps to Test or Reproduce

Assuming you are running everything in containers, navigate to  http://default/events
1. Add a new Event
2. Click on Event Details
3.  Add a new store
4. Click save
5. Edit an existing store or add a new store.  Refresh the page if needed
## Impacted Areas in Application

List general components of the application that this PR will affect:
- web application
- node server models

@boundlessgeo/spatial-connect
