### PR TITLE
added development and container configs for api url

### DIFF
--- a/web/config/container.js
+++ b/web/config/container.js
@@ -1,0 +1,1 @@
+export const API_URL = 'http://default:3000/api/';

--- a/web/config/development.js
+++ b/web/config/development.js
@@ -1,0 +1,1 @@
+export const API_URL = 'http://localhost:3000/api/';

--- a/web/config/test.js
+++ b/web/config/test.js
@@ -1,0 +1,1 @@
+export const API_URL = 'http://localhost:3000/api/';

--- a/web/ducks/dataStores.js
+++ b/web/ducks/dataStores.js
@@ -1,8 +1,8 @@
 'use strict';
 import { reset } from 'redux-form';
 import * as request from 'superagent';
-const API_URL = 'http://default:3000/api/'; // TODO: make this an env var
- import uuid from 'node-uuid';
+import { API_URL } from 'config';
+import uuid from 'node-uuid';
 
 // define action types
 export const LOAD = 'sc/dataStores/LOAD';

--- a/web/ducks/events.js
+++ b/web/ducks/events.js
@@ -1,7 +1,7 @@
 'use strict';
 import { reset } from 'redux-form';
 import * as request from 'superagent';
-const API_URL = 'http://default:3000/api/'; // TODO: make this an env var
+import { API_URL } from 'config';
 
 // define action types
 export const LOAD = 'sc/events/LOAD';

--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,7 @@
     "expect": "^1.8.0",
     "jsdom": "^5.6.1",
     "mocha": "^2.4.5",
+    "mock-require": "^1.2.1",
     "nock": "^7.2.2",
     "node-libs-browser": "^0.5.2",
     "react-addons-test-utils": "^0.14.7",

--- a/web/test/events.js
+++ b/web/test/events.js
@@ -4,7 +4,8 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import nock from 'nock';
 import * as events from '../ducks/events';
-import reducer from '../ducks/events'
+import reducer from '../ducks/events';
+import { API_URL } from 'config';
 
 // test the action creators that return an object
 describe('events action creators', () => {
@@ -42,7 +43,7 @@ describe('events async action creators', () => {
       'name': 'some name',
       'description': 'some description'
     }];
-    nock('http://default:3000/api/')
+    nock(API_URL)
       .get('/events')
       .reply(200, eventsResponse);
     const expectedActions = [
@@ -59,10 +60,10 @@ describe('events async action creators', () => {
       'description': 'some description'
     };
     const eventsResponse = [ mockEvent ];
-    nock('http://default:3000/api/')
+    nock(API_URL)
       .get('/events')
       .reply(200, eventsResponse);
-    nock('http://default:3000/api/')
+    nock(API_URL)
       .post('/events')
       .reply(200);
     const expectedActions = [

--- a/web/test/setup.js
+++ b/web/test/setup.js
@@ -1,5 +1,9 @@
 'use strict';
+import path from 'path';
 import { jsdom } from 'jsdom'
+import mock from 'mock-require';
+
+mock('config', path.join(__dirname, '../config', process.env.NODE_ENV || 'development'));
 
 global.document = jsdom('<!doctype html><html><body></body></html>')
 global.window = document.defaultView

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -27,5 +27,10 @@ module.exports = {
         include: __dirname
       }
     ]
+  },
+  resolve: {
+    alias: {
+      config: path.join(__dirname, 'config', process.env.NODE_ENV || 'development')
+    }
   }
 };


### PR DESCRIPTION
## Status

**READY**
## Description

This allows the API url to be set using environmental variables. Currently has `container`, `development`, and `test` configs. If NODE_ENV is undefined, it will use `development`.
## Todos
- [ ] Tests
- [ ] Documentation
## Deploy Notes

Notes regarding deployment the contained body of work.
## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

``` sh
git pull --prune
git checkout api-url-variable
cd web; npm test
```
## Impacted Areas in Application

This affects the event and dataStore models
- 

@boundlessgeo/spatial-connect

add mock test config

use dev config if NODE_ENV is not set

use config api for tests

move mock require to setup
