### PR TITLE
adding fix to build with development api url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,8 @@ WORKDIR /usr/src/web
 COPY web /usr/src/web
 RUN npm install --silent
 RUN npm install webpack -g --silent
+ENV NODE_ENV=development
 RUN webpack
-COPY web/dist/bundle.js /usr/src/web/dist/bundle.js
-
 
 # Copy server source to server dir
 RUN mkdir -p /usr/src/server


### PR DESCRIPTION
## Status

**READY**
## JIRA Ticket

SPACON-32
## Description

Fixes issue to point to development api url by default when building the container
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License
## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

``` sh
git fetch --all
git checkout <feature_branch> 
npm test
```

@boundlessgeo/spatial-connect
