### PR TITLE
adding type to device registration

### DIFF
--- a/server/migrations/sqls/20160614201339-create-tables-up.sql
+++ b/server/migrations/sqls/20160614201339-create-tables-up.sql
@@ -38,8 +38,8 @@ ALTER TABLE public.forms
 CREATE TABLE IF NOT EXISTS public.devices
 (
   id SERIAL PRIMARY KEY,
-  name TEXT,
-  identifier TEXT,
+  identifier text UNIQUE,
+  device_info json,
   created_at timestamp DEFAULT NOW(),
   updated_at timestamp DEFAULT NOW(),
   deleted_at timestamp with time zone

--- a/server/migrations/sqls/20160614201430-add-data-up.sql
+++ b/server/migrations/sqls/20160614201430-add-data-up.sql
@@ -2,8 +2,8 @@ INSERT INTO stores (name,store_type,version,uri,id) VALUES ('gj1','geojson','1',
 INSERT INTO stores (name,store_type,version,uri,id) VALUES ('gj2','geojson','1','feature.geojson','3e6c072e-8e62-41be-8d1a-7a3116df9c16');
 INSERT INTO stores (name,store_type,version,uri,id) VALUES ('Haiti','gpkg','1','http://www.geopackage.org/data/haiti-vectors-split.gpkg','f6dcc750-1349-46b9-a324-0223764d46d1');
 INSERT INTO stores (name,store_type,version,uri,id) VALUES ('Whitehorse','gpkg','1','https://portal.opengeospatial.org/files/63156','fad33ae1-f529-4c79-affc-befc37c104ae');
-INSERT INTO devices (name,identifier) VALUES ('iphone','afsasdfasdfasdfsf');
-INSERT INTO devices (name,identifier) VALUES ('android',';ljljlkjljljljlkj');
+INSERT INTO devices (identifier,device_info) VALUES ('07b962d7-d091-4dad-8c4e-a083694d34b0', '{"os": "Android"}');
+INSERT INTO devices (identifier,device_info) VALUES ('0c20b743-5485-4109-823c-c9c4f54038c4', '{"os": "iOS"}');
 INSERT INTO forms (form_key,form_label) VALUES ('weed_inspector','Weed Inspector');
 
 INSERT INTO form_fields (form_id,position,field_key,field_label,type,is_integer,is_required)

--- a/server/models/devices.js
+++ b/server/models/devices.js
@@ -2,11 +2,11 @@
 
 module.exports = (sequelize,DataTypes) => {
   var Devices = sequelize.define('Devices',{
-    name : DataTypes.STRING,
     identifier : {
       type : DataTypes.STRING,
       unique : true
-    }
+    },
+    device_info : DataTypes.JSON
   },{
     timestamps : true,
     paranoid : true,

--- a/server/routes/devices.js
+++ b/server/routes/devices.js
@@ -7,8 +7,8 @@ var Rx = require('rx');
 
 router.post('/register', (req, res) => {
   Rx.Observable.fromPromise(models.Devices.upsert({
-    identifier : req.body.identifier,
-    name : req.body.name
+    identifier: req.body.identifier,
+    device_info: req.body.device_info
   })).subscribe(
     () => res.json({success:true}),
     (err) => res.json({success:false,message:err})


### PR DESCRIPTION
## Status

**READY**
## JIRA Ticket

SPACON-190
## Description

Adding migration and updating routes to accept a `type` attribute when registering a device. 
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License
## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

``` sh
git fetch --all
git checkout <feature_branch> 
npm test
```

@boundlessgeo/spatial-connect
