### PR TITLE
Fixing bug where server connects to undefined channel

### DIFF
--- a/server/mqttroutes/stores.js
+++ b/server/mqttroutes/stores.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var StoreCommands = require('./../commands/store');
+var Rx = require('rx');
 
 module.exports = (mqttClient,dispatcher) => {
   let listenOnTopic = (topic) => {
@@ -11,7 +12,7 @@ module.exports = (mqttClient,dispatcher) => {
       );
   };
 
-  StoreCommands.stores()
+  StoreCommands.stores().flatMap(Rx.Observable.fromArray)
     .subscribe(
       (store) => {
         listenOnTopic('/store/'+store.id);


### PR DESCRIPTION
## Status

**READY**
## Description

Due to refactoring the MQTT client was connecting to `stores/undefined`
## Todos
- [x] Tests
- [x] Documentation
- [x] License
## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

``` sh
git fetch --all
git checkout bugfix/mqtt_store_conn_undef
npm test
```

@boundlessgeo/spatial-connect
