### PR TITLE
Add HTTP responses

### DIFF
--- a/spaconclj/spacon/src/spacon/components/config.clj
+++ b/spaconclj/spacon/src/spacon/components/config.clj
@@ -2,6 +2,7 @@
   (:require [com.stuartsierra.component :as component]
             [spacon.util.protobuf :as pbf]
             [spacon.http.intercept :as intercept]
+            [spacon.http.response :as response]
             [spacon.components.mqtt :as mqtt]
             [spacon.models.store :as store]))
 
@@ -10,7 +11,7 @@
 
 (defn http-get [context]
   (let [d (create-config)]
-    (intercept/ok d)))
+    (response/success d)))
 
 (defn- routes [] #{["/api/config" :get
                     (conj intercept/common-interceptors `http-get)]

--- a/spaconclj/spacon/src/spacon/components/device.clj
+++ b/spaconclj/spacon/src/spacon/components/device.clj
@@ -1,6 +1,7 @@
 (ns spacon.components.device
   (:require [com.stuartsierra.component :as component]
             [spacon.http.intercept :as intercept]
+            [spacon.http.response :as response]
             [clojure.data.json :as json]
             [spacon.db.conn :as db]
             [yesql.core :refer [defqueries]]
@@ -61,28 +62,28 @@
 
 (defn http-get [context]
   (let [d (device-list)]
-    (intercept/ok d)))
+    (response/success d)))
 
 (defn http-get-device [context]
   (if-let [id (get-in context [:path-params :id])]
-    (intercept/ok (find-device id))
-    (intercept/error nil)))
+    (response/success (find-device id))
+    (response/error nil)))
 
 (defn http-post-device [context]
   (if-let [d (create-device (:json-params context))]
-    (intercept/ok d)
-    (intercept/error "Error creating")))
+    (response/success d)
+    (response/error "Error creating")))
 
 (defn http-put-device [context]
   (if-let [d (update-device
                (get-in context [:path-params :id])
                (:json-params context))]
-    (intercept/ok d)
-    (intercept/error "Error updating")))
+    (response/success d)
+    (response/error "Error updating")))
 
 (defn http-delete-device [context]
   (delete-device (get-in context [:path-params :id]))
-  (intercept/ok "success"))
+  (response/success "success"))
 
 (defn- routes [] #{["/api/devices" :get
                     (conj intercept/common-interceptors `http-get)]

--- a/spaconclj/spacon/src/spacon/components/location.clj
+++ b/spaconclj/spacon/src/spacon/components/location.clj
@@ -1,6 +1,7 @@
 (ns spacon.components.location
   (:require [com.stuartsierra.component :as component]
             [spacon.http.intercept :as intercept]
+            [spacon.http.response :as response]
             [clojure.data.json :as json]
             [spacon.db.conn :as db]
             [yesql.core :refer [defqueries]]
@@ -40,7 +41,7 @@
 
 (defn http-get [context]
   (let [fs (location->geojson (locations))]
-    (intercept/ok {:type     "FeatureCollection"
+    (response/success {:type     "FeatureCollection"
                                     :features fs})))
 
 (defn- routes [] #{["/api/location" :get

--- a/spaconclj/spacon/src/spacon/components/ping.clj
+++ b/spaconclj/spacon/src/spacon/components/ping.clj
@@ -1,11 +1,12 @@
 (ns spacon.components.ping
   (:require [com.stuartsierra.component :as component]
             [spacon.http.intercept :as intercept]
+            [spacon.http.response :as response]
             [clojure.data.json :as json]))
 
 (defn- pong
   [request]
-  (intercept/ok "pong"))
+  (response/success "pong"))
 
 (defn- routes [] #{["/api/ping" :get (conj intercept/common-interceptors `pong)]})
 

--- a/spaconclj/spacon/src/spacon/components/store.clj
+++ b/spaconclj/spacon/src/spacon/components/store.clj
@@ -1,35 +1,41 @@
 (ns spacon.components.store
   (:require [com.stuartsierra.component :as component]
             [spacon.http.intercept :as intercept]
+            [spacon.http.response :as response]
             [spacon.models.store :as store]))
 
 (defn http-get [context]
   (if-let [d (store/store-list)]
-    (intercept/ok d)
-    (intercept/error "Error")))
+    (response/success d)
+    (response/error "Error")))
+
+(defn http-get-error [context]
+    (response/error "Error"))
 
 (defn http-get-store [context]
   (if-let [d (store/find-store (get-in context [:path-params :id]))]
-    (intercept/ok d)
-    (intercept/error "Error retrieving store")))
+    (response/success d)
+    (response/error "Error retrieving store")))
 
 (defn http-put-store [context]
   (if-let [d (store/update-store (get-in context [:path-params :id])
                                   (:json-params context))]
-    (intercept/ok "success")
-    (intercept/error "Error updating")))
+    (response/success "success")
+    (response/error "Error updating")))
 
 (defn http-post-store [context]
   (if-let [d (store/create-store (:json-params context))]
-    (intercept/ok d)
-    (intercept/error "Error creating")))
+    (response/success d)
+    (response/error "Error creating")))
 
 (defn http-delete-store [context]
   (store/delete-store (get-in context [:path-params :id]))
-  (intercept/ok "success"))
+  (response/success "success"))
 
 (defn- routes [] #{["/api/stores" :get
                     (conj intercept/common-interceptors `http-get)]
+                   ["/api/stores-error" :get
+                    (conj intercept/common-interceptors `http-get-error)]
                    ["/api/stores/:id" :get
                     (conj intercept/common-interceptors `http-get-store)]
                    ["/api/stores/:id" :put

--- a/spaconclj/spacon/src/spacon/components/team.clj
+++ b/spaconclj/spacon/src/spacon/components/team.clj
@@ -1,6 +1,6 @@
 (ns spacon.components.team
   (:require [com.stuartsierra.component :as component]
-            [com.stuartsierra.component :as component]
+            [yesql.core :refer [defqueries]]
             [spacon.db.conn :as db]))
 
 (defqueries "sql/team.sql" {:connection db/db-spec})

--- a/spaconclj/spacon/src/spacon/components/trigger.clj
+++ b/spaconclj/spacon/src/spacon/components/trigger.clj
@@ -4,7 +4,8 @@
             [spacon.util.db :as dbutil]
             [yesql.core :refer [defqueries]]
             [clojure.data.json :as json]
-            [spacon.http.intercept :as intercept])
+            [spacon.http.intercept :as intercept]
+            [spacon.http.response :as response])
   (:import (org.postgresql.util PGobject)))
 
 (defqueries "sql/trigger.sql"
@@ -59,27 +60,27 @@
   (delete-trigger! {:id (java.util.UUID/fromString id)}))
 
 (defn http-get [context]
-  (intercept/ok (trigger-list)))
+  (response/success (trigger-list)))
 
 (defn http-get-trigger [context]
   (if-let [d (find-trigger (get-in context [:path-params :id]))]
-    (intercept/ok d)
-    (intercept/error "Error retrieving")))
+    (response/success d)
+    (response/error "Error retrieving")))
 
 (defn http-put-trigger [context]
   (if-let [d (update-trigger (get-in context [:path-params :id])
                              (:json-params context))]
-    (intercept/ok d)
-    (intercept/error "Error updating ")))
+    (response/success d)
+    (response/error "Error updating ")))
 
 (defn http-post-trigger [context]
   (if-let [d (create-trigger (:json-params context))]
-    (intercept/ok d)
-    (intercept/error "Error creating")))
+    (response/success d)
+    (response/error "Error creating")))
 
 (defn http-delete-trigger [context]
   (delete-trigger (get-in context [:path-params :id]))
-  (intercept/ok "success"))
+  (response/success "success"))
 
 (defn- routes [] #{["/api/triggers" :get
                     (conj intercept/common-interceptors `http-get)]

--- a/spaconclj/spacon/src/spacon/components/user.clj
+++ b/spaconclj/spacon/src/spacon/components/user.clj
@@ -8,7 +8,7 @@
             [clojure.spec :as s]))
 
 (defn get-all-users [context]
-  (response/success (map user/sanitize (user/find-all)) "Content-Type" "application/json"))
+  (response/success (map user/sanitize (user/find-all))))
 
 (defn create-user
   "Creates a new user"

--- a/spaconclj/spacon/src/spacon/http/auth.clj
+++ b/spaconclj/spacon/src/spacon/http/auth.clj
@@ -2,6 +2,7 @@
   (:require [io.pedestal.interceptor.helpers :refer [defbefore defhandler]]
             [io.pedestal.interceptor.chain :refer [terminate]]
             [spacon.http.intercept :as intercept]
+            [spacon.http.response :as response]
             [buddy.hashers :as hashers]
             [buddy.auth.protocols :as proto]
             [buddy.auth.backends :as backends]
@@ -26,7 +27,7 @@
                     :exp  (-> 2 weeks from-now)}
             ;; todo: encrypt the token
             token (jwt/sign claims secret)]
-        (intercept/ok {:token token})))))
+        (response/success {:token token})))))
 
 
 (defhandler authorize-user

--- a/spaconclj/spacon/src/spacon/http/intercept.clj
+++ b/spaconclj/spacon/src/spacon/http/intercept.clj
@@ -14,7 +14,6 @@
 
 (defn transform-content
   [body content-type]
-  (println "transform-content" content-type)
   (case content-type
     "text/html"        (json/write-str body)
     "text/plain"       (json/write-str body)

--- a/spaconclj/spacon/src/spacon/http/response.clj
+++ b/spaconclj/spacon/src/spacon/http/response.clj
@@ -1,0 +1,22 @@
+(ns spacon.http.response)
+
+(defn is-error? [status]
+  (< 300 status))
+
+(defn response [status body & {:as headers}]
+  (println "response" body headers)
+  (let [res-body (assoc {}
+                    :result (if (is-error? status) nil body)
+                    :error (if (is-error? status) body nil))]
+    {:status status :body res-body :headers headers}))
+
+(def success (partial response 200))
+(def created (partial response 201))
+(def accepted (partial response 202))
+(def bad-request (partial response 400))
+(def unauthorized (partial response 401))
+(def forbidden (partial response 403))
+(def not-found (partial response 404))
+(def conflict (partial response 409))
+(def error (partial response 500))
+(def unavailable (partial response 503))

--- a/spaconclj/spacon/src/spacon/http/response.clj
+++ b/spaconclj/spacon/src/spacon/http/response.clj
@@ -4,7 +4,6 @@
   (< 300 status))
 
 (defn response [status body & {:as headers}]
-  (println "response" body headers)
   (let [res-body (assoc {}
                     :result (if (is-error? status) nil body)
                     :error (if (is-error? status) body nil))]


### PR DESCRIPTION
## Status
**READY**

## Description
- All HTTP responses now have result and error keys.
```
{ status: 200, body: { result: [], error: null } }
{ status: 500, body: { result: null, error: "Error Message" } }
```
- Response content type is always application/json
- Added more HTTP response codes

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch --all
git checkout <feature_branch> 
npm test
```

@boundlessgeo/spatial-connect

