### PR TITLE
rename success to ok for http status

### DIFF
--- a/spaconclj/spacon/src/spacon/components/config.clj
+++ b/spaconclj/spacon/src/spacon/components/config.clj
@@ -11,7 +11,7 @@
 
 (defn http-get [context]
   (let [d (create-config)]
-    (response/success d)))
+    (response/ok d)))
 
 (defn- routes [] #{["/api/config" :get
                     (conj intercept/common-interceptors `http-get)]

--- a/spaconclj/spacon/src/spacon/components/device.clj
+++ b/spaconclj/spacon/src/spacon/components/device.clj
@@ -62,28 +62,28 @@
 
 (defn http-get [context]
   (let [d (device-list)]
-    (response/success d)))
+    (response/ok d)))
 
 (defn http-get-device [context]
   (if-let [id (get-in context [:path-params :id])]
-    (response/success (find-device id))
+    (response/ok (find-device id))
     (response/error nil)))
 
 (defn http-post-device [context]
   (if-let [d (create-device (:json-params context))]
-    (response/success d)
+    (response/ok d)
     (response/error "Error creating")))
 
 (defn http-put-device [context]
   (if-let [d (update-device
                (get-in context [:path-params :id])
                (:json-params context))]
-    (response/success d)
+    (response/ok d)
     (response/error "Error updating")))
 
 (defn http-delete-device [context]
   (delete-device (get-in context [:path-params :id]))
-  (response/success "success"))
+  (response/ok "success"))
 
 (defn- routes [] #{["/api/devices" :get
                     (conj intercept/common-interceptors `http-get)]

--- a/spaconclj/spacon/src/spacon/components/location.clj
+++ b/spaconclj/spacon/src/spacon/components/location.clj
@@ -41,7 +41,7 @@
 
 (defn http-get [context]
   (let [fs (location->geojson (locations))]
-    (response/success {:type     "FeatureCollection"
+    (response/ok {:type                       "FeatureCollection"
                                     :features fs})))
 
 (defn- routes [] #{["/api/location" :get

--- a/spaconclj/spacon/src/spacon/components/ping.clj
+++ b/spaconclj/spacon/src/spacon/components/ping.clj
@@ -6,7 +6,7 @@
 
 (defn- pong
   [request]
-  (response/success "pong"))
+  (response/ok "pong"))
 
 (defn- routes [] #{["/api/ping" :get (conj intercept/common-interceptors `pong)]})
 

--- a/spaconclj/spacon/src/spacon/components/store.clj
+++ b/spaconclj/spacon/src/spacon/components/store.clj
@@ -6,7 +6,7 @@
 
 (defn http-get [context]
   (if-let [d (store/store-list)]
-    (response/success d)
+    (response/ok d)
     (response/error "Error")))
 
 (defn http-get-error [context]
@@ -14,23 +14,23 @@
 
 (defn http-get-store [context]
   (if-let [d (store/find-store (get-in context [:path-params :id]))]
-    (response/success d)
+    (response/ok d)
     (response/error "Error retrieving store")))
 
 (defn http-put-store [context]
   (if-let [d (store/update-store (get-in context [:path-params :id])
                                   (:json-params context))]
-    (response/success "success")
+    (response/ok "success")
     (response/error "Error updating")))
 
 (defn http-post-store [context]
   (if-let [d (store/create-store (:json-params context))]
-    (response/success d)
+    (response/ok d)
     (response/error "Error creating")))
 
 (defn http-delete-store [context]
   (store/delete-store (get-in context [:path-params :id]))
-  (response/success "success"))
+  (response/ok "success"))
 
 (defn- routes [] #{["/api/stores" :get
                     (conj intercept/common-interceptors `http-get)]

--- a/spaconclj/spacon/src/spacon/components/trigger.clj
+++ b/spaconclj/spacon/src/spacon/components/trigger.clj
@@ -60,27 +60,27 @@
   (delete-trigger! {:id (java.util.UUID/fromString id)}))
 
 (defn http-get [context]
-  (response/success (trigger-list)))
+  (response/ok (trigger-list)))
 
 (defn http-get-trigger [context]
   (if-let [d (find-trigger (get-in context [:path-params :id]))]
-    (response/success d)
+    (response/ok d)
     (response/error "Error retrieving")))
 
 (defn http-put-trigger [context]
   (if-let [d (update-trigger (get-in context [:path-params :id])
                              (:json-params context))]
-    (response/success d)
+    (response/ok d)
     (response/error "Error updating ")))
 
 (defn http-post-trigger [context]
   (if-let [d (create-trigger (:json-params context))]
-    (response/success d)
+    (response/ok d)
     (response/error "Error creating")))
 
 (defn http-delete-trigger [context]
   (delete-trigger (get-in context [:path-params :id]))
-  (response/success "success"))
+  (response/ok "success"))
 
 (defn- routes [] #{["/api/triggers" :get
                     (conj intercept/common-interceptors `http-get)]

--- a/spaconclj/spacon/src/spacon/components/user.clj
+++ b/spaconclj/spacon/src/spacon/components/user.clj
@@ -8,7 +8,7 @@
             [clojure.spec :as s]))
 
 (defn get-all-users [context]
-  (response/success (map user/sanitize (user/find-all))))
+  (response/ok (map user/sanitize (user/find-all))))
 
 (defn create-user
   "Creates a new user"
@@ -16,7 +16,7 @@
   (let [user (get-in context [:request :json-params])]
     (if (s/valid? :spacon.models.user/spec user)
       (if-let [new-user (user/add-user! user)]
-        (response/success (user/sanitize new-user)))
+        (response/ok (user/sanitize new-user)))
         (response/error (str "failed to crueate user:\n" (s/explain-str :spacon.models.user/spec user))))))
 
 (defn- routes []

--- a/spaconclj/spacon/src/spacon/http/auth.clj
+++ b/spaconclj/spacon/src/spacon/http/auth.clj
@@ -27,7 +27,7 @@
                     :exp  (-> 2 weeks from-now)}
             ;; todo: encrypt the token
             token (jwt/sign claims secret)]
-        (response/success {:token token})))))
+        (response/ok {:token token})))))
 
 
 (defhandler authorize-user

--- a/spaconclj/spacon/src/spacon/http/response.clj
+++ b/spaconclj/spacon/src/spacon/http/response.clj
@@ -9,7 +9,7 @@
                     :error (if (is-error? status) body nil))]
     {:status status :body res-body :headers headers}))
 
-(def success (partial response 200))
+(def ok (partial response 200))
 (def created (partial response 201))
 (def accepted (partial response 202))
 (def bad-request (partial response 400))


### PR DESCRIPTION
## Status
**READY**

## Description
Renaming `success` to `ok` for the response to follow the [HTTP spec](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch --all
git checkout <feature_branch> 
npm test
```

@boundlessgeo/spatial-connect
