### PR TITLE
Add polling option for WFS + GeoJSON Stores

### DIFF
--- a/spaconclj/spacon/resources/migrations/004-options.down.sql
+++ b/spaconclj/spacon/resources/migrations/004-options.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE stores DROP COLUMN options;
+ALTER TABLE forms DROP COLUMN options;

--- a/spaconclj/spacon/resources/migrations/004-options.up.sql
+++ b/spaconclj/spacon/resources/migrations/004-options.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE stores ADD COLUMN options json;
+ALTER TABLE forms ADD COLUMN options json;

--- a/spaconclj/spacon/resources/sql/store.sql
+++ b/spaconclj/spacon/resources/sql/store.sql
@@ -14,8 +14,8 @@ WHERE id = :id AND deleted_at IS NULL
 
 -- name: insert-store<!
 -- creates a new store
-INSERT INTO stores (name,store_type,version,uri,default_layers,team_id,created_at,updated_at)
-VALUES (:name,:store_type,:version,:uri,:default_layers, :team_id, NOW(), NOW())
+INSERT INTO stores (name,store_type,version,uri,options,default_layers,team_id,created_at,updated_at)
+VALUES (:name,:store_type,:version,:uri,:options::json,:default_layers, :team_id, NOW(), NOW())
 
 -- name: update-store<!
 -- updates store
@@ -25,6 +25,7 @@ store_type = :store_type,
 version = :version,
 uri = :uri,
 team_id = :team_id,
+options = :options::json,
 default_layers = :default_layers,
 updated_at = NOW()
 WHERE id = :id

--- a/web/components/DataStoreForm.js
+++ b/web/components/DataStoreForm.js
@@ -156,6 +156,7 @@ export class DataStoreForm extends Component {
         {this.state.show_polling ?
           <div className="form-group">
             <label>Polling:</label>
+            <p className="help-block">Number of seconds (0 - 600)</p>
             <input type="text" className="form-control" defaultValue={this.state.polling} ref="polling" maxLength={5} />
             {errors.polling ? <p className="text-danger">{errors.polling}</p> : ''}
           </div> : ''

--- a/web/components/DataStoreForm.js
+++ b/web/components/DataStoreForm.js
@@ -23,6 +23,17 @@ export const validate = values => {
   if (values.store_type === 'wfs' && !values.default_layers.length) {
     errors.default_layers = 'Must choose at least one default layer.';
   }
+  if (values.options && values.options.polling) {
+    let msg = 'Must be a number of seconds between 1 and 600';
+    let p = parseFloat(values.options.polling);
+    if (!isNaN(p) && isFinite(values.options.polling)) {
+      if (p % 1 !== 0 || p < 1 || p > 600) {
+        errors.polling = msg;
+      }
+    } else {
+      errors.polling = msg;
+    }
+  }
   return errors;
 };
 
@@ -31,7 +42,9 @@ export class DataStoreForm extends Component {
     super(props);
     this.state = {
       store_type: null,
-      default_layers: props.store.default_layers || false
+      default_layers: props.store.default_layers || false,
+      polling: props.store.options && props.store.options.polling ? props.store.options.polling : null,
+      show_polling: props.store.store_type === 'geojson' || props.store.store_type === 'wfs',
     };
   }
 
@@ -40,10 +53,15 @@ export class DataStoreForm extends Component {
       name: this.refs.name.value,
       store_type: this.refs.store_type.value,
       version: this.refs.version.value.trim(),
-      uri: this.refs.uri.value.trim()
+      uri: this.refs.uri.value.trim(),
     }
     if (this.refs.default_layers) {
       store.default_layers = this.getChosenLayers();
+    }
+    if (this.refs.polling) {
+      store.options = {
+        polling: this.refs.polling.value.trim(),
+      };
     }
     let errors = validate(store);
     this.props.actions.updateStoreErrors(errors);
@@ -55,6 +73,13 @@ export class DataStoreForm extends Component {
   onStoreTypeChange() {
     this.setState({store_type: this.refs.store_type.value});
     this.shouldUpdateLayerList();
+    this.addPollingOption();
+  }
+
+  addPollingOption() {
+    this.setState({
+      show_polling: (this.refs.store_type.value === 'geojson' || this.refs.store_type.value === 'wfs')
+    });
   }
 
   shouldUpdateLayerList() {
@@ -126,6 +151,13 @@ export class DataStoreForm extends Component {
             ))}
             </select>
             {errors.default_layers ? <p className="text-danger">{errors.default_layers}</p> : ''}
+          </div> : ''
+        }
+        {this.state.show_polling ?
+          <div className="form-group">
+            <label>Polling:</label>
+            <input type="text" className="form-control" defaultValue={this.state.polling} ref="polling" maxLength={5} />
+            {errors.polling ? <p className="text-danger">{errors.polling}</p> : ''}
           </div> : ''
         }
         <div className="btn-toolbar">

--- a/web/components/DataStoreItem.js
+++ b/web/components/DataStoreItem.js
@@ -13,6 +13,8 @@ const DataStoreItem = ({ store }) => (
       <PropertyListItem name={'URI'} value={store.uri} />
       <PropertyListItem name={'Version'} value={store.version} />
       <PropertyListItem name={'Team'} value={store.team_name} />
+      {(store.options && store.options.polling) &&
+      <PropertyListItem name={'Polling Interval'} value={store.options.polling} />}
       {store.default_layers.length ?
         <PropertyListItem name={'Default Layers'} value={store.default_layers.join(', ')} />
         : '' }

--- a/web/containers/DataStoresContainer.js
+++ b/web/containers/DataStoresContainer.js
@@ -12,7 +12,8 @@ let emptyStore = {
   name: '',
   version: '1',
   uri: '',
-  store_type: ''
+  store_type: '',
+  options: {},
 };
 
 export class DataStoresContainer extends Component {


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
SPACON-380
SPACON-381

## Description
- Adds `options` json column to stores
- GeoJSON and WFS store create forms have a polling input field
- Polling interval must be integer between 1 and 600
- Polling option is not required

## Todos
- [x] Add form help notes


@boundlessgeo/spatial-connect

