### PR TITLE
change update to assoc

### DIFF
--- a/server/src/spacon/components/ping/core.clj
+++ b/server/src/spacon/components/ping/core.clj
@@ -16,7 +16,7 @@
 (defn mqtt-ping [mqttcomp message]
   (mqttapi/publish-scmessage mqttcomp
                              (:reply-to message)
-                             (update message :payload {:result "pong"})))
+                             (assoc message :payload {:result "pong"})))
 
 (defrecord PingComponent [mqtt]
   component/Lifecycle


### PR DESCRIPTION
## Status
**READY**

## Description
We want to return `{"result": "pong"}` as the payload of the response to the ping request over MQTT.  `update` doesn't work but `assoc` does