### PR TITLE
build custom nginx container instead of data volume container

### DIFF
--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -1,0 +1,13 @@
+FROM nginx:alpine
+
+RUN apk add --update nodejs
+
+RUN mkdir -p /web
+COPY . /web
+RUN rm -rf /web/node_modules/
+WORKDIR /web
+RUN npm install
+RUN npm run build:dev
+
+COPY ./nginx-config/default.conf /etc/nginx/conf.d/default.conf
+COPY ./dist/ /usr/share/nginx/html

--- a/web/Dockerfile.nginx-config
+++ b/web/Dockerfile.nginx-config
@@ -1,7 +1,0 @@
-FROM busybox
-
-COPY ./nginx-config/default.conf /etc/nginx/conf.d/default.conf
-COPY ./dist/ /usr/share/nginx/html
-
-VOLUME /etc/nginx/conf.d
-VOLUME /usr/share/nginx/html

--- a/web/README.md
+++ b/web/README.md
@@ -1,8 +1,16 @@
 ## spatialconnect-server-dashboard
 
+
 The SpatialConnect Dashboard is a web application that allows users to configure
 events, data stores, notifications, users, and other properties of
 the spatialconnect-server.
+
+
+### to run for local development
+
+```
+npm run start:local
+```
 
 ### testing
 
@@ -13,11 +21,8 @@ npm test
 ```
 
 
-### build the data volume container for nginx
-```
-# first build the static assests for the environment
-NODE_ENV=development webpack
+### to build the nginx container for the environment
 
-# then build a data volume container for the environment
-docker build -t boundlessgeo/spatialconnect-nginx-config:development -f Dockerfile.nginx-config .
+```
+docker build -t boundlessgeo/spatialconnect-server:web-dev -f Dockerfile.dev .
 ```


### PR DESCRIPTION
## Status
**READY**

## Description
We want to dynamically build the static assets for a specific environment when we push to specific branches.  Instead of building a [data volume container](https://docs.docker.com/engine/tutorials/dockervolumes/#/creating-and-mounting-a-data-volume-container), it now builds custom nginx container with the appropriate config files for the environment, to make auto-redeployment easier.
