### PR TITLE
fix bug with location parsing & test

### DIFF
--- a/server/src/spacon/components/location/core.clj
+++ b/server/src/spacon/components/location/core.clj
@@ -26,8 +26,8 @@
   "MQTT message handler that persists the device location
   of the message body, then tests it against the triggers"
   [trigger message]
-  (log/debug "Received device location update")
-  (let [loc (json/read-str (:payload message) :key-fn clojure.core/keyword)]
+  (log/debugf "Received device location update message %s" (:payload message))
+  (let [loc (:payload message)]
     (locationmodel/upsert-gj loc)
     (triggerapi/test-value trigger "location" loc)))
 


### PR DESCRIPTION
## Status
**READY**

## Description
This fixes an issue I introduced that caused the tests to pass but the devices location updates to fail to persist.  The test was sending location update messages that were formatted differently than what the devices were sending.