### PR TITLE
initial implementation of kafka component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ server/test.js
 # ignore this file b/c it's generated
 web/public/index.html
 
+# ignore kafka & zookeeper data
+data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,24 @@
 version: '2'
 services:
   zookeeper:
-    image: confluent/zookeeper:3.4.6-cp1
+    image: wurstmeister/zookeeper:3.4.6
     ports:
       - '2181:2181'
+    volumes:
+      - './data/zookeeper:/opt/zookeeper-3.4.6/data'
 
   kafka:
-    image: confluent/kafka:0.10.0.0-cp1
+    image: wurstmeister/kafka:0.10.1.1
+    environment:
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ADVERTISED_HOST_NAME: localhost
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     ports:
       - '9092:9092'
-    environment:
-      - KAFKA_ADVERTISED_HOST_NAME=
-      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
-      - KAFKA_LOG_CLEANUP_POLICY=compact
+    links:
+      - zookeeper
+    volumes:
+      - './data/kafka:/kafka'
 
   nginx:
     image: jwilder/nginx-proxy
@@ -47,9 +53,6 @@ services:
       - VIRTUAL_HOST=spatialconnect-server
       - TRUST_STORE=/opt/server/tls/test-cacerts.jks
       - KEY_STORE=/opt/server/tls/test-keystore.p12
-
-  kafka-tools:
-    image: confluent/tools:0.9.0.0-cp1
 
   geoserver:
     image: kartoza/geoserver:latest

--- a/server/dev/user.clj
+++ b/server/dev/user.clj
@@ -45,7 +45,14 @@
                                      ::server/allowed-origins {:creds true
                                                                :allowed-origins (constantly true)}}
                        :mqtt-config {:broker-url (or (System/getenv "MQTT_BROKER_URL")
-                                                     "tcp://localhost:1883")}}))
+                                                     "tcp://localhost:1883")}
+                       :kafka-producer-config {:servers  (or (System/getenv "BOOTSTRAP_SERVERS")
+                                                             "localhost:9092")
+                                               :timeout-ms 2000}
+                       :kafka-consumer-config {:servers  (or (System/getenv "BOOTSTRAP_SERVERS")
+                                                             "localhost:9092")
+                                               :group-id (or (System/getenv "GROUP_ID")
+                                                             "sc-consumers")}}))
 
 (def system-val nil)
 

--- a/server/project.clj
+++ b/server/project.clj
@@ -32,7 +32,9 @@
                  [com.gfredericks/test.chuck "0.2.7"]
                  [jonase/eastwood "0.2.3" :exclusions [org.clojure/clojure]]
                  [com.draines/postal "2.0.2"]
-                 [org.clojure/tools.logging "0.3.1"]]
+                 [org.clojure/tools.logging "0.3.1"]
+                 [org.apache.kafka/kafka-clients "0.10.1.1"]
+                 [clj-time "0.13.0"]]
 
   :repositories  [["osgeo" "http://download.osgeo.org/webdav/geotools/"]
                   ["boundlessgeo-releases" "https://repo.boundlessgeo.com/artifactory/release/"]

--- a/server/src/spacon/components/kafka/core.clj
+++ b/server/src/spacon/components/kafka/core.clj
@@ -1,0 +1,94 @@
+;; Copyright 2016-2017 Boundless, http://boundlessgeo.com
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns spacon.components.kafka.core
+  (:require [com.stuartsierra.component :as component]
+            [clojure.core.async :as async]
+            [clojure.core.async.impl.protocols :as p]
+            [clojure.tools.logging :as log])
+  (:import [org.apache.kafka.clients.producer Producer MockProducer KafkaProducer ProducerRecord Callback RecordMetadata]
+           [org.apache.kafka.clients.consumer Consumer MockConsumer KafkaConsumer ConsumerRecord OffsetResetStrategy]
+           [org.apache.kafka.common.serialization Serializer Deserializer StringSerializer StringDeserializer]
+           [org.apache.kafka.common.errors WakeupException]
+           [org.apache.kafka.common TopicPartition]))
+
+(defn construct-producer
+  "Construct and return a KafkaProducer using the producer-config map
+  (See https://kafka.apache.org/documentation.html#producerconfigs
+  for more details about the config)"
+  [producer-config]
+  (let [{:keys [servers timeout-ms client-id config key-serializer value-serializer]
+         :or   {config           {}
+                key-serializer   (StringSerializer.)
+                value-serializer (StringSerializer.)
+                client-id        (str "sc-producer-" (.getHostName (java.net.InetAddress/getLocalHost)))}}
+        producer-config]
+    (KafkaProducer. ^java.util.Map
+                    (assoc config
+                      "request.timeout.ms" (str timeout-ms)
+                      "bootstrap.servers" servers
+                      "client.id" client-id
+                      "acks" "all")
+                    ^Serializer key-serializer
+                    ^Serializer value-serializer)))
+
+(defrecord ProducerComponent [producer-config]
+  component/Lifecycle
+  (start [this]
+    (log/debug "Starting ProducerComponent")
+    (assoc this :producer (construct-producer producer-config)))
+  (stop  [this]
+    (log/debug "Stopping ProducerComponent")
+    (.close (:producer this))
+    this))
+
+(defn make-producer-component
+  [producer-config]
+  (map->ProducerComponent {:producer-config producer-config}))
+
+;; todo: write specs for valid records that we accept
+;; for instance, restrict the topics and keys that can be sent
+;; keys should be time-based uuids? --> use [danlentz/clj-uuid "0.1.7"]
+(defn- producer-record
+  "Constructs a ProducerRecord from a map"
+  [record]
+  (let [{:keys [topic partition key value]} record]
+    (cond
+      (and partition key) (ProducerRecord. topic (int partition) key value)
+      key                 (ProducerRecord. topic key value)
+      :else               (ProducerRecord. topic value))))
+
+
+(defn send!
+  "Sends a record (a map of :topic, :value and optionally :key, :partition) using the given Producer component.
+  Returns ch (a promise-chan unless otherwise specified) where record metadata will be put after it's successfuly sent."
+  ([producer-component record]
+   (send! producer-component record (async/promise-chan)))
+  ([producer-component record ch]
+   (let [^Producer producer (:producer producer-component)]
+     (.send producer
+            (producer-record record)
+            (reify
+              Callback
+              (^void onCompletion [_ ^RecordMetadata rm ^Exception e]
+                (let [ret (when rm
+                            {:offset    (.offset rm)
+                             :partition (.partition rm)
+                             :topic     (.topic rm)
+                             :timestamp (.timestamp rm)})]
+                  (async/put! ch (or ret e))))))
+     ch)))
+
+
+

--- a/server/src/spacon/components/ping/core.clj
+++ b/server/src/spacon/components/ping/core.clj
@@ -18,16 +18,42 @@
             [spacon.components.http.response :as response]
             [spacon.components.mqtt.core :as mqttapi]
             [clojure.data.json :as json]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log]
+            [spacon.components.kafka.core :as kafka]
+            [clojure.core.async :as async]
+            [clj-time.local :as l])
+  (:import [java.util.concurrent Executors TimeUnit]))
 
 (defn- pong
   "Responds with pong as a way to ensure http service is reachable"
   [request]
   (response/ok "pong"))
 
-(defn- routes [] #{["/api/ping"
-                    :get
-                    (conj intercept/common-interceptors `pong)]})
+(defn pong-kafka
+  "Subscribes to test topic and awaits pong message to ensure kafka cluster is reachable"
+  [producer-component request]
+  (let [record {:topic "test"
+                :key "anykey"
+                :value (json/write-str (:json-params request))}
+        promise-chan (kafka/send! producer-component record)
+        [val ch] (async/alts!! [promise-chan (async/timeout 2000)])]
+    (if (nil? val)
+      (response/error "Error writing to Kafka or timeout")
+      (response/ok val))))
+
+(defn- send-ping [kafka-producer]
+  (let [ping-msg (json/write-str {:type "ping"
+                                  :timestamp (l/format-local-time (l/local-now) :date-time-no-ms)})]
+    (kafka/send! kafka-producer {:topic "test"
+                                 :value ping-msg
+                                 :key "anykey"
+                                 :partition 0})))
+
+(defn- ping-kafka
+  "Sends a record to kafka every 5 seconds as a heartbeat."
+  [kafka-producer]
+  (let [pool (Executors/newScheduledThreadPool 1)]
+    (.scheduleAtFixedRate pool #(send-ping kafka-producer) 0 5 TimeUnit/SECONDS)))
 
 (defn mqtt-ping
   "Responds with pong as a way to ensure mqtt broker is reachable"
@@ -36,12 +62,19 @@
                              (:reply-to message)
                              (assoc message :payload {:result "pong"})))
 
-(defrecord PingComponent [mqtt]
+(defn- routes
+  [kafka-producer]
+  #{["/api/ping" :get (conj intercept/common-interceptors `pong)]
+    ["/api/ping/kafka" :post (conj intercept/common-interceptors (partial pong-kafka kafka-producer)) :route-name :pong-kafka]})
+
+
+(defrecord PingComponent [mqtt kafka-producer]
   component/Lifecycle
   (start [this]
     (log/debug "Starting Ping Component")
     (mqttapi/subscribe mqtt "/ping" (partial mqtt-ping mqtt))
-    (assoc this :routes (routes)))
+    (ping-kafka kafka-producer)
+    (assoc this :routes (routes kafka-producer)))
   (stop [this]
     (log/debug "Stopping Ping Component")
     this))


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
SPACON-585

## Description
* Add a Kafka component with a producer for sending records to a cluster. 
* Updates docker configuration to run kafka + zookeeper locally
* Add producer heartbeat on test topic
* Adds a ping method to send data onto test topic

## Todos
- [ ] Tests
- [x] Documentation
- [x] License

## Steps to Test or Reproduce
You can start kafka with `docker-compose up -d kafka`.  

Then you can consume from the test topic using the kafka console consumer:
```
kafka-console-consumer --bootstrap-server localhost:9092 --topic test --from-beginning
```
Finally, to send test data onto the test topic, you can post to the ping endpoint:
```
curl http://localhost:8085/api/ping/kafka -H 'Content-Type: application/json'  -d '{"foo": "bar"}'
```
