### PR TITLE
Fix url word-wrap

### DIFF
--- a/web/style/FormList.less
+++ b/web/style/FormList.less
@@ -62,7 +62,8 @@
       }
       .value {
         font-weight: 600;
-        word-wrap: normal;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
         white-space: pre-wrap;
       }
     }


### PR DESCRIPTION
## Status
**READY**

## Description
Before
<img width="311" alt="screen shot 2017-02-17 at 9 52 40 am" src="https://cloud.githubusercontent.com/assets/410285/23070027/b25e8e72-f4f7-11e6-8301-e6ccd4d76407.png">
After
<img width="309" alt="screen shot 2017-02-17 at 9 56 27 am" src="https://cloud.githubusercontent.com/assets/410285/23070033/b80d862a-f4f7-11e6-879e-172920f3c6ed.png">


@boundlessgeo/spatial-connect
