### PR TITLE
auto migrate the db schema during development mode

### DIFF
--- a/server/dev/user.clj
+++ b/server/dev/user.clj
@@ -23,6 +23,7 @@
 
 (defn init-dev []
   (log/info "Initializing dev system for repl")
+  (spacon.db.conn/migrate)
   (System/setProperty "javax.net.ssl.trustStore"
                       (or (System/getenv "TRUST_STORE")
                           "tls/test-cacerts.jks"))
@@ -59,6 +60,7 @@
 
 (defn init-signal-dev []
   (log/info "Initializing dev system for repl")
+  (spacon.db.conn/migrate)
   (System/setProperty "javax.net.ssl.trustStore"
                       (or (System/getenv "TRUST_STORE")
                           "tls/test-cacerts.jks"))

--- a/server/src/spacon/server.clj
+++ b/server/src/spacon/server.clj
@@ -96,7 +96,6 @@
   (System/setProperty "javax.net.ssl.keyStorePassword"
                       (or (System/getenv "KEY_STORE_PASSWORD")
                           "somepass"))
-  ;; todo: auto migrate flag?
   (component/start-system
    (make-spacon-server {:http-config {}
                         :mqtt-config {:broker-url (System/getenv "MQTT_BROKER_URL")}

--- a/server/src/spacon/signal.clj
+++ b/server/src/spacon/signal.clj
@@ -57,6 +57,8 @@
   "The entry-point for 'lein run'"
   [& _]
   (log/info "Configuring Signal server...")
+  (if (= "DEV" (System/getenv "ENV"))
+    (spacon.db.conn/migrate))
   ;; create global uncaught exception handler so threads don't silently die
   (Thread/setDefaultUncaughtExceptionHandler
     (reify Thread$UncaughtExceptionHandler
@@ -80,6 +82,5 @@
   (System/setProperty "javax.net.ssl.keyStorePassword"
                       (or (System/getenv "KEY_STORE_PASSWORD")
                           "somepass"))
-  ;; todo: auto migrate flag?
   (component/start-system
     (make-signal-server {:http-config {}})))


### PR DESCRIPTION
## Status
**READY**

## Description
When running using the REPL or setting the `ENV` environment variable to `DEV`, the db will be automatically migrated.  

```
ENV=DEV lein with-profile signal run
```