### PR TITLE
updating mqtt component to handle broker reconnection

### DIFF
--- a/server/src/spacon/components/mqtt/core.clj
+++ b/server/src/spacon/components/mqtt/core.clj
@@ -20,9 +20,11 @@
             [spacon.components.http.response :as response]
             [clojure.core.async :as async]
             [spacon.components.http.auth :refer [get-token]]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log])
+  (:import (org.eclipse.paho.client.mqttv3 MqttException)))
 
-(def client-id "spacon-server")
+(def client-id (str "sc-" (.getCanonicalHostName (java.net.InetAddress/getLocalHost))))
+(defonce conn (atom nil))
 
 (def topics
   "Map of topics as keys and message handler functions as values"
@@ -46,35 +48,52 @@
   "Connect to mqtt broker at url
    Example url: ssl://broker.hostname.domain:port"
   [url]
-  (log/debug "Connecting MQTT Client at" url)
-  (mh/connect url client-id))
+  (while (or (nil? @conn) (not (mh/connected? @conn)))
+    (log/debugf "Connecting MQTT Client to %s" url)
+    (try
+      (do
+        (reset! conn (mh/connect url client-id))
+        (log/infof "MQTT Client connected to %s" url))
+      (catch MqttException e
+        (do
+          (log/error e "Failed to connect to" url)
+          ; wait 4 seconds befor trying again
+          (Thread/sleep 4000))))))
+
 
 ; publishes message on the send channel
 (defn- publish [mqtt topic message]
-  (log/tracef "Publishing to topic %s %nmessage: %s" topic message)
+  (log/debugf "Publishing to topic: %s %nmessage: %s" topic (into {} message))
   (async/go (async/>!! (:publish-channel mqtt) {:topic topic :message (scm/message->bytes message)})))
 
 ; receive message on subscribe channel
 (defn- receive [mqtt topic message]
-  (log/tracef "Received message on topic %s %nmessage:%s" topic message)
+  (log/tracef "Received message on topic:  %nmessage: %s" topic message)
   (if (nil? message)
     (log/debug "Nil message on topic " topic)
     (async/go (async/>!! (:subscribe-channel mqtt) {:topic topic :message (scm/from-bytes message)}))))
+
+(defn reconnect [reason]
+  (let [url  (System/getenv "MQTT_BROKER_URL")]
+    (log/debugf "%s%nConnection lost. Attempting reconnect to %s" reason url)
+    (connectmqtt url)))
 
 (defn subscribe
   "Subscribe to mqtt topic with message handler function f"
   [mqtt topic f]
   (log/debug "Subscribing to topic" topic)
   (add-topic topic f)
-  (mh/subscribe (:conn mqtt) {topic 2} (fn [^String topic _ ^bytes payload]
-                                         (receive mqtt topic payload))))
+  (mh/subscribe @conn {topic 2}
+                (fn [^String topic _ ^bytes payload]
+                    (receive mqtt topic payload))
+                {:on-connection-lost reconnect}))
 
 (defn unsubscribe
   "Unsubscribe to mqtt topic"
   [mqtt topic]
   (log/debug "Unsubscribing to topic" topic)
   (remove-topic topic)
-  (mh/unsubscribe (:conn mqtt) topic))
+  (mh/unsubscribe @conn topic))
 
 (defn- process-publish-channel [mqtt chan]
   (async/go (while true
@@ -82,8 +101,12 @@
                     t (:topic v)
                     m (:message v)]
                 (try
-                  (if-not (or (nil? t) (nil? m))
-                    (mh/publish (:conn mqtt) t m))
+                  (if-not (mh/connected? @conn)
+                    (do (reconnect nil)
+                      (if-not (or (nil? t) (nil? m))
+                        (mh/publish @conn t m)))
+                    (if-not (or (nil? t) (nil? m))
+                      (mh/publish @conn t m)))
                   (catch Exception e
                     (log/error "Could not publish message b/c"
                                (.getLocalizedMessage e))))))))
@@ -121,7 +144,7 @@
     (log/debug "Stopping MQTT Component")
     (async/close! (:publish-channel this))
     (async/close! (:subscribe-channel this))
-    (mh/disconnect (:conn this))
+    (mh/disconnect @conn)
     this))
 
 (defn make-mqtt-component [mqtt-config]


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
SPACON-419

## Description
* Ensures that the broker can connect on startup, and blocks until it's connected.  
* Ensures that the broker is connected before publishing a message.  
* Ensures that when the client disconnects because the server kills the connection, it tries to reconnect to the broker.
* Also, add an identifier to the mqtt client so we know which host the server is connecting from

## Steps to Test or Reproduce
You can simulate the reconnection by stopping or restarting your mqtt broker.
