### PR TITLE
Link server to kafka in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     image: wurstmeister/kafka:0.10.1.1
     environment:
       KAFKA_ADVERTISED_PORT: 9092
-      KAFKA_ADVERTISED_HOST_NAME: localhost
+      KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     ports:
       - '9092:9092'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
     ports:
       - '8085:8085'
     environment:
+      - BOOTSTRAP_SERVERS=kafka:9092
       - DB_HOST=postgis
       - MQTT_BROKER_URL=ssl://mosquitto:8884
       - VIRTUAL_HOST=spatialconnect-server


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
N/A

## Description
Adds Kafka environment variables to docker-compose.yml so that `docker-compose up spatialconnect-server` starts without exception. Also changes the Kafka service's KAFKA_ADVERTISED_HOST_NAME to kafka to match the container name.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

## Steps to Test or Reproduce
```sh
git fetch --all
git checkout link-server-to-kafka-in-compose
docker-compose up spatialconnect-server
```

Expected behaviour is that the server starts and responds to requests at localhost:8085.

Actual behaviour is an exception in stdout (fails to create Kafka producer), server process remains running (container does not exit) and does not respond on port 8085.


@boundlessgeo/spatial-connect
