### PR TITLE
Modifying schema creation to use clojure/java.jdbc

### DIFF
--- a/server/dev/user.clj
+++ b/server/dev/user.clj
@@ -42,7 +42,6 @@
                                                                    "sc-consumers")}}))
 (defn init-dev []
   (log/info "Initializing dev system for repl")
-  (spacon.db.conn/create-spacon-schema)
   (spacon.db.conn/migrate)
   (System/setProperty "javax.net.ssl.trustStore"
                       (or (System/getenv "TRUST_STORE")
@@ -87,4 +86,3 @@
 (defn reset []
   (stop)
   (go))
-

--- a/server/project.clj
+++ b/server/project.clj
@@ -6,7 +6,6 @@
   :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
                  [org.clojure/core.async "0.3.442"]
                  [org.clojure/data.json "0.2.6"]
-                 [org.clojure/java.jdbc "0.7.0-alpha3"]
                  [io.pedestal/pedestal.service "0.5.1"]
                  [io.pedestal/pedestal.jetty "0.5.1"]
                  [ragtime "0.5.3"]

--- a/server/project.clj
+++ b/server/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
                  [org.clojure/core.async "0.3.442"]
                  [org.clojure/data.json "0.2.6"]
+                 [org.clojure/java.jdbc "0.7.0-alpha3"]
                  [io.pedestal/pedestal.service "0.5.1"]
                  [io.pedestal/pedestal.jetty "0.5.1"]
                  [ragtime "0.5.3"]

--- a/server/resources/sql/schema.sql
+++ b/server/resources/sql/schema.sql
@@ -1,2 +1,0 @@
--- name: create-spacon-schema!
-CREATE SCHEMA IF NOT EXISTS spacon;

--- a/server/src/spacon/db/conn.clj
+++ b/server/src/spacon/db/conn.clj
@@ -17,7 +17,6 @@
   (:require [ragtime.jdbc :as jdbc]
             [ragtime.repl :as repl]
             [clojure.data.json :as json]
-            [clojure.java.jdbc :as sql]
             [jdbc.pool.c3p0 :as pool]
             [clojure.tools.logging :as log]))
 
@@ -44,19 +43,19 @@
       :min-pool-size     2
       :initial-pool-size 2})))
 
+(defn create-schema []
+  (log/debug "Creating schema if it doesnt exist")
+  (clojure.java.jdbc/execute! db-spec ["CREATE SCHEMA IF NOT EXISTS spacon"]))
+
 (defn loadconfig []
   (log/debug "Loading database migration config")
+  (create-schema)
   {:datastore  (jdbc/sql-database db-spec {:migrations-table "spacon.migrations"})
    :migrations (jdbc/load-resources "migrations")})
 
-(defn create-schema []
-  (log/debug "Creating schema if it doesnt exist")
-  (sql/execute! db-spec ["CREATE SCHEMA IF NOT EXISTS spacon"])
-  (repl/migrate (loadconfig)))
-
 (defn migrate []
   (log/debug "Running database migration")
-  (repl/migrate (create-schema)))
+  (repl/migrate (loadconfig)))
 
 (defn rollback []
   (log/debug "Rolling back database migration")

--- a/server/src/spacon/db/conn.clj
+++ b/server/src/spacon/db/conn.clj
@@ -14,10 +14,10 @@
 
 (ns spacon.db.conn
   (:import com.mchange.v2.c3p0.ComboPooledDataSource)
-  (:require [yesql.core :refer [defqueries]]
-            [ragtime.jdbc :as jdbc]
+  (:require [ragtime.jdbc :as jdbc]
             [ragtime.repl :as repl]
             [clojure.data.json :as json]
+            [clojure.java.jdbc :as sql]
             [jdbc.pool.c3p0 :as pool]
             [clojure.tools.logging :as log]))
 
@@ -44,17 +44,19 @@
       :min-pool-size     2
       :initial-pool-size 2})))
 
-(defqueries "sql/schema.sql" {:connection db-spec})
-(defn create-spacon-schema [] (create-spacon-schema!))
-
 (defn loadconfig []
   (log/debug "Loading database migration config")
   {:datastore  (jdbc/sql-database db-spec {:migrations-table "spacon.migrations"})
    :migrations (jdbc/load-resources "migrations")})
 
+(defn create-schema []
+  (log/debug "Creating schema if it doesnt exist")
+  (sql/execute! db-spec ["CREATE SCHEMA IF NOT EXISTS spacon"])
+  (repl/migrate (loadconfig)))
+
 (defn migrate []
   (log/debug "Running database migration")
-  (repl/migrate (loadconfig)))
+  (repl/migrate (create-schema)))
 
 (defn rollback []
   (log/debug "Rolling back database migration")

--- a/server/src/spacon/server.clj
+++ b/server/src/spacon/server.clj
@@ -106,7 +106,6 @@
   [& _]
   (log/info "Configuring the server...")
   (if (= "true" (System/getenv "AUTO_MIGRATE"))
-    (spacon.db.conn/create-spacon-schema)
     (spacon.db.conn/migrate))
   ;; create global uncaught exception handler so threads don't silently die
   (Thread/setDefaultUncaughtExceptionHandler
@@ -134,4 +133,3 @@
   (if (= "kafka" (System/getenv "QUEUE_TYPE"))
     (start-kafka-system)
     (start-mqtt-system)))
-


### PR DESCRIPTION
## Status
IN DEVELOPMENT

## Description
Adjustment to the below, but modifying schema creation to use clojure/java.jdbc

Adds ability to auto create schema if AUTO_MIGRATE is true (or on spinning up the dev environment from the repl)