### PR TITLE
manifest consolidation for L2 PCF

### DIFF
--- a/cf/efc-db.json
+++ b/cf/efc-db.json
@@ -1,0 +1,8 @@
+{
+   "db_username": "spacondev",
+   "db_name": "spacondev",
+   "postgis": true,
+   "db_encoding": "UTF-8",
+   "owner_email": "api@boundlessgeo.com",
+   "owner_name": "boundless"
+}

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,34 @@
+# build steps
+#############
+# NOTE: run the following from the root of spatialconnect-server
+#############
+# pushd web && npm install && npm run build:devio && popd
+# pushd server && lein uberjar && popd
+# if ! cf s | grep 'efc-db-test'; then cf cs pg_95_XL_DEV_SHARED_001 large-dev-100 efc-db-test -c cf/efc-db.json; fi
+# cf push
+#############
+---
+applications:
+  - name: efc-web-test
+    # added domain due to ssl support not working on default domain
+    domain: dev.dev.east.paas.geointservices.io
+    buildpack: staticfile_buildpack
+    memory: 64M
+    instances: 1
+    path: ./web/public
+  - name: efc-test
+    # added domain due to ssl support not working on default domain
+    domain: dev.dev.east.paas.geointservices.io
+    buildpack: java_buildpack_offline
+    memory: 2G
+    instances: 1
+    path: ./server/target/spacon-server.jar
+    env:
+      ALLOWED_ORIGINS: https://efc-web-test.dev.dev.east.paas.geointservices.io
+      AUTO_MIGRATE: true
+      ENV: DEV
+      KEY_STORE: /app/server/tls/test-keystore.p12
+      MQTT_CLIENT_ID: spacon-server-devio
+      TRUST_STORE: /app/server/tls/test-cacerts.jks
+    services:
+      - efc-db-test

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,6 +5,7 @@
 # pushd web && npm install && npm run build:devio && popd
 # pushd server && lein uberjar && popd
 # if ! cf s | grep 'efc-db-test'; then cf cs pg_95_XL_DEV_SHARED_001 large-dev-100 efc-db-test -c cf/efc-db.json; fi
+# if ! cf S | grep 'efc-mqtt-test'; then cf cs p-rabbitmq standard efc-mqtt-test; fi
 # cf push
 #############
 ---
@@ -32,3 +33,4 @@ applications:
       TRUST_STORE: /app/server/tls/test-cacerts.jks
     services:
       - efc-db-test
+      - efc-mqtt-test

--- a/server/src/spacon/components/mqtt/core.clj
+++ b/server/src/spacon/components/mqtt/core.clj
@@ -30,10 +30,11 @@
   "Map of keys and values from VCAP_SERVICES mqtt environment variable"
   (or (some-> (System/getenv "VCAP_SERVICES")
               (json/read-str :key-fn clojure.core/keyword) :p-rabbitmq first :credentials :protocols :mqtt)
-              {:username
-               :password
-               :host
-               :port}))
+                {:username :username
+                 :password :password
+                 :host :host
+                 :port :port
+                 :ssl :ssl}))
 
 (def mqtt-connect-ops
   "Map of authentication keys and values for mqtt connect options"
@@ -43,7 +44,7 @@
 (def vcap_tcp
   "When vcap_mqtt exists it returns a formated tcp connection"
   (when (some? vcap_mqtt)
-        (format "%s://%s:%s" "tcp" (:host vcap_mqtt) (:port vcap_mqtt))))
+        (format "%s://%s:%s" (if (:ssl vcap_mqtt) "ssl" "tcp") (:host vcap_mqtt) (:port vcap_mqtt))))
 
 (def client-id (or (System/getenv "MQTT_CLIENT_ID")
                    (subs (str "sc-" (InetAddress/getLocalHost)) 0 22 )))


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## JIRA Ticket
CAPI-241

## Description
- deploys efc and efc-web
- includes notes and json to create db
- manifest now includes step to create the service and binding to the efc app
- created a Map for keys and values found if VCAP_SERVICESS mqtt exists
- Added connection options to pass to the connect function to include username and password to the connection.
- Parses SSL from VCAP if enabled

## Todos
Note: We still have an open ticket to make the mqtt public, currently it is a private ip.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

see manifest.yml
