### PR TITLE
Change form results endpoint to return data for all form versions

### DIFF
--- a/server/resources/sql/form.sql
+++ b/server/resources/sql/form.sql
@@ -114,3 +114,8 @@ WHERE form_id = :form_id;
 -- Gets the data submissions for a form for all versions
 SELECT * FROM spacon.form_data
 WHERE form_id IN (SELECT id FROM spacon.forms WHERE form_key = :form_key)
+
+-- name: get-form-data-version-query
+-- Gets the data submissions for a form for a version
+SELECT * FROM spacon.form_data
+WHERE form_id = (SELECT id FROM spacon.forms WHERE form_key = :form_key AND version = :form_version)

--- a/server/resources/sql/form.sql
+++ b/server/resources/sql/form.sql
@@ -109,3 +109,8 @@ WHERE form_id = :form_id GROUP BY updated_at ORDER BY updated_at DESC LIMIT 1;
 -- Gets the data submissions for a form
 SELECT * FROM spacon.form_data
 WHERE form_id = :form_id;
+
+-- name: get-form-data-all-query
+-- Gets the data submissions for a form for all versions
+SELECT * FROM spacon.form_data
+WHERE form_id IN (SELECT id FROM spacon.forms WHERE form_key = :form_key)

--- a/server/src/spacon/components/form/core.clj
+++ b/server/src/spacon/components/form/core.clj
@@ -65,8 +65,8 @@
 
 (defn get-form-data
   "Retrieves data for a specific form"
-  [form-comp form-id]
-  (formmodel/get-form-data form-id))
+  [form-comp form-key]
+  (formmodel/get-form-data form-key))
 
 (defn add-form-data
   [form-comp form-data form-id device-id]

--- a/server/src/spacon/components/form/core.clj
+++ b/server/src/spacon/components/form/core.clj
@@ -68,6 +68,11 @@
   [form-comp form-key]
   (formmodel/get-form-data form-key))
 
+(defn get-form-data-version
+  "Retrieves data for a specific form"
+  [form-comp form-key form-version]
+  (formmodel/get-form-data-version form-key form-version))
+
 (defn add-form-data
   [form-comp form-data form-id device-id]
   (let [gj (-> form-data

--- a/server/src/spacon/components/form/db.clj
+++ b/server/src/spacon/components/form/db.clj
@@ -44,9 +44,9 @@
                     :form_id form-id
                     :device_identifier device-identifier}))
 
-(defn get-form-data [form-id]
-  (map sanitize (get-form-data-query
-                 {:form_id (Integer/parseInt form-id)})))
+(defn get-form-data [form-key]
+  (map sanitize (get-form-data-all-query
+                 {:form_key form-key})))
 
 (defn form-fields
   "Gets the fields for a specific form"

--- a/server/src/spacon/components/form/db.clj
+++ b/server/src/spacon/components/form/db.clj
@@ -48,6 +48,11 @@
   (map sanitize (get-form-data-all-query
                  {:form_key form-key})))
 
+(defn get-form-data-version [form-key form-version]
+  (map sanitize (get-form-data-version-query
+                  {:form_key form-key
+                   :form_version (Integer/parseInt form-version)})))
+
 (defn form-fields
   "Gets the fields for a specific form"
   [form]

--- a/server/src/spacon/components/http/form.clj
+++ b/server/src/spacon/components/http/form.clj
@@ -101,6 +101,14 @@
   (let [form-key (get-in request [:path-params :form-key])]
     (response/ok (formapi/get-form-data form-comp form-key))))
 
+(defn http-get-form-results-version
+  "Gets the form submissions for given form version"
+  [form-comp request]
+  (log/debug "Fetching form data")
+  (let [form-key (get-in request [:path-params :form-key])
+        form-version (get-in request [:path-params :form-version])]
+    (response/ok (formapi/get-form-data-version form-comp form-key form-version))))
+
 (defn routes [form-comp queue]
   #{["/api/forms"                :get
      (conj common-interceptors check-auth (partial http-get-all-forms form-comp)) :route-name :all-forms]
@@ -113,6 +121,9 @@
     ["/api/forms/:form-key/results" :get
      (conj common-interceptors check-auth (partial http-get-form-results form-comp))
      :route-name :form-results]
+    ["/api/forms/:form-key/results/:form-version" :get
+     (conj common-interceptors check-auth (partial http-get-form-results-version form-comp))
+     :route-name :form-results-version]
     ;; todo: need to figure out why forms causes a route conflict
     ["/api/form/:form-id/submit"  :post
      (conj common-interceptors check-auth (partial http-submit-form-data form-comp))

--- a/server/src/spacon/components/http/form.clj
+++ b/server/src/spacon/components/http/form.clj
@@ -98,8 +98,8 @@
   "Gets the form submissions for given form"
   [form-comp request]
   (log/debug "Fetching form data")
-  (let [form-id (get-in request [:path-params :form-id])]
-    (response/ok (formapi/get-form-data form-comp form-id))))
+  (let [form-key (get-in request [:path-params :form-key])]
+    (response/ok (formapi/get-form-data form-comp form-key))))
 
 (defn routes [form-comp queue]
   #{["/api/forms"                :get
@@ -110,13 +110,13 @@
      (conj common-interceptors check-auth (partial http-delete-form-by-key form-comp queue)) :route-name :delete-form]
     ["/api/forms/:form-key"      :get
      (conj common-interceptors check-auth (partial http-get-form form-comp)) :route-name :get-form]
+    ["/api/forms/:form-key/results" :get
+     (conj common-interceptors check-auth (partial http-get-form-results form-comp))
+     :route-name :form-results]
     ;; todo: need to figure out why forms causes a route conflict
     ["/api/form/:form-id/submit"  :post
      (conj common-interceptors check-auth (partial http-submit-form-data form-comp))
      :route-name :submit-form :constraints {:form-id #"[0-9]+"}]
-    ["/api/form/:form-id/results" :get
-     (conj common-interceptors check-auth (partial http-get-form-results form-comp))
-     :route-name :form-results :constraints {:form-id #"[0-9]+"}]
     ["/api/form/:form-id/sample" :get
      (conj common-interceptors check-auth (partial http-get-sample-form-data form-comp))
      :route-name :sample-form-data :constraints {:form-id #"[0-9]+"}]})

--- a/web/ducks/data.js
+++ b/web/ducks/data.js
@@ -90,7 +90,7 @@ export function getFormData(form) {
     const { sc } = getState();
     const token = sc.auth.token;
     return request
-      .get(`${API_URL}form/${form.id}/results`)
+      .get(`${API_URL}forms/${form.form_key}/results`)
       .set('Authorization', `Token ${token}`)
       .then(res => res.body.result)
       .then(data =>
@@ -112,7 +112,7 @@ export function loadFormDataAll() {
       forms.map(form => {
         dispatch(addFormId(form.id));
         return request
-          .get(`${API_URL}form/${form.id}/results`)
+          .get(`${API_URL}forms/${form.form_key}/results`)
           .set('Authorization', `Token ${token}`)
           .then(res => res.body.result)
           .then(data =>


### PR DESCRIPTION
## Status
**READY**

## Description
- changes `/form/:form-id/results` to `/forms/:form-key/results` so that results for all versions of a form are returned