### PR TITLE
Add unique constraint to form data table

### DIFF
--- a/server/resources/migrations/007-form-data-uq.down.sql
+++ b/server/resources/migrations/007-form-data-uq.down.sql
@@ -1,0 +1,18 @@
+--  Copyright 2016-2017 Boundless, http://boundlessgeo.com
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+
+alter table spacon.form_data drop column submission_id;
+alter table spacon.form_data drop column layer_id;
+
+alter table spacon.form_data drop constraint form_data_uq;

--- a/server/resources/migrations/007-form-data-uq.down.sql
+++ b/server/resources/migrations/007-form-data-uq.down.sql
@@ -12,7 +12,7 @@
 --  See the License for the specific language governing permissions and
 --  limitations under the License.
 
-alter table spacon.form_data drop column submission_id;
-alter table spacon.form_data drop column layer_id;
-
-alter table spacon.form_data drop constraint form_data_uq;
+alter table spacon.form_data
+drop column if exists submission_id,
+drop column if exists layer_id,
+drop constraint if exists form_data_uq;

--- a/server/resources/migrations/007-form-data-uq.up.sql
+++ b/server/resources/migrations/007-form-data-uq.up.sql
@@ -1,0 +1,20 @@
+--  Copyright 2016-2017 Boundless, http://boundlessgeo.com
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+
+alter table spacon.form_data add column submission_id integer;
+alter table spacon.form_data add column layer_id text;
+
+alter table spacon.form_data
+add constraint form_data_uq
+unique (layer_id, submission_id);

--- a/server/resources/migrations/007-form-data-uq.up.sql
+++ b/server/resources/migrations/007-form-data-uq.up.sql
@@ -12,9 +12,7 @@
 --  See the License for the specific language governing permissions and
 --  limitations under the License.
 
-alter table spacon.form_data add column submission_id integer;
-alter table spacon.form_data add column layer_id text;
-
 alter table spacon.form_data
-add constraint form_data_uq
-unique (layer_id, submission_id);
+add column submission_id integer,
+add column layer_id text,
+add constraint form_data_uq unique (layer_id, submission_id);

--- a/server/resources/sql/form.sql
+++ b/server/resources/sql/form.sql
@@ -100,7 +100,7 @@ DO UPDATE SET (
 INSERT INTO spacon.form_data (val,form_id,submission_id,layer_id,device_id)
 VALUES (:val::jsonb,:form_id,:submission_id,:layer_id,(SELECT id FROM spacon.devices WHERE identifier = :device_identifier));
 ON CONFLICT ON CONSTRAINT form_data_uq
-DO UPDATE SET updated_at = now();
+DO UPDATE SET updated_at = now(), val = :val;
 
 -- name: form-data-stats-query
 -- Gets some metadata about the submissions for a form

--- a/server/resources/sql/form.sql
+++ b/server/resources/sql/form.sql
@@ -97,8 +97,8 @@ DO UPDATE SET (
 
 -- name: add-form-data<!
 -- Adds form data submitted FROM spacon.a device
-INSERT INTO spacon.form_data (val,form_id,device_id)
-VALUES (:val::jsonb,:form_id,(SELECT id FROM spacon.devices WHERE identifier = :device_identifier));
+INSERT INTO spacon.form_data (val,form_id,submission_id,layer_id,device_id)
+VALUES (:val::jsonb,:form_id:submission_id,:layer_id,(SELECT id FROM spacon.devices WHERE identifier = :device_identifier));
 
 -- name: form-data-stats-query
 -- Gets some metadata about the submissions for a form

--- a/server/resources/sql/form.sql
+++ b/server/resources/sql/form.sql
@@ -98,7 +98,9 @@ DO UPDATE SET (
 -- name: add-form-data<!
 -- Adds form data submitted FROM spacon.a device
 INSERT INTO spacon.form_data (val,form_id,submission_id,layer_id,device_id)
-VALUES (:val::jsonb,:form_id:submission_id,:layer_id,(SELECT id FROM spacon.devices WHERE identifier = :device_identifier));
+VALUES (:val::jsonb,:form_id,:submission_id,:layer_id,(SELECT id FROM spacon.devices WHERE identifier = :device_identifier));
+ON CONFLICT ON CONSTRAINT form_data_uq
+DO UPDATE SET updated_at = now();
 
 -- name: form-data-stats-query
 -- Gets some metadata about the submissions for a form

--- a/server/src/spacon/components/form/core.clj
+++ b/server/src/spacon/components/form/core.clj
@@ -112,7 +112,7 @@
                .getDefaultGeometry)]
     (let [valid-feature (if (s/valid? :spacon.specs.geojson/pointfeature-spec form-data)
                           (do
-                            (log/debug "Submitting form data")
+                            (log/debugf "Submitting form data" form-data)
                             (formmodel/add-form-data form-data form-id device-identifier)
                             {:result true :error nil})
                           {:result false :error (s/explain-str :spacon.specs.geojson/pointfeature-spec form-data)})]

--- a/server/src/spacon/components/form/core.clj
+++ b/server/src/spacon/components/form/core.clj
@@ -112,7 +112,7 @@
                .getDefaultGeometry)]
     (let [valid-feature (if (s/valid? :spacon.specs.geojson/pointfeature-spec form-data)
                           (do
-                            (log/debugf "Submitting form data" form-data)
+                            (log/debug "Submitting form data")
                             (formmodel/add-form-data form-data form-id device-identifier)
                             {:result true :error nil})
                           {:result false :error (s/explain-str :spacon.specs.geojson/pointfeature-spec form-data)})]

--- a/server/src/spacon/components/form/db.clj
+++ b/server/src/spacon/components/form/db.clj
@@ -41,7 +41,7 @@
 
 (defn add-form-data [val form-id device-identifier]
   (add-form-data<! {:val     (json/write-str val)
-                    :submission_id (:id val)
+                    :submission_id (Integer/parseInt (:id val))
                     :layer_id (:layerId (:metadata val))
                     :form_id form-id
                     :device_identifier device-identifier}))

--- a/server/src/spacon/components/form/db.clj
+++ b/server/src/spacon/components/form/db.clj
@@ -41,6 +41,8 @@
 
 (defn add-form-data [val form-id device-identifier]
   (add-form-data<! {:val     (json/write-str val)
+                    :submission_id (:id val)
+                    :layer_id (:layerId (:metadata val))
                     :form_id form-id
                     :device_identifier device-identifier}))
 


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
SPACON-668

## Description
This adds a unique constraint to the form_data table based on a form submissions `id` and `layerId`.

## Todos
- [x] Ensure that the Android SDK is sending the submission id and layerId the same way the iOS sdk is

@boundlessgeo/spatial-connect
