### PR TITLE
Firebase Push notification endpoint

### DIFF
--- a/server/project.clj
+++ b/server/project.clj
@@ -38,7 +38,9 @@
                  [org.apache.kafka/kafka-streams "0.10.0.0-cp1"
                   :exclusions [org.slf4j/slf4j-log4j12]]
                  [clj-time "0.13.0"]
-                 [ymilky/franzy "0.0.1"]]
+                 [ymilky/franzy "0.0.1"]
+                 [clj-http "3.6.1"]]
+
 
   :repositories  [["osgeo" "http://download.osgeo.org/webdav/geotools/"]
                   ["boundlessgeo-releases" "https://repo.boundlessgeo.com/artifactory/release/"]

--- a/server/src/spacon/components/http/notification.clj
+++ b/server/src/spacon/components/http/notification.clj
@@ -9,12 +9,13 @@
     (response/ok (notifapi/find-notif-by-id notif-comp id))))
 
 (defn http-send-notif
-  "Send push notification json body"
+  "Send push notification, if :to is present just sent to device if not send to all devices"
   [notif-comp request]
   (let [notif-data (get-in request [:json-params])]
-    (notifapi/send->devices notif-data)
+    (if (nil? (:to notif-data))
+      (notifapi/notify notif-data)
+      (notifapi/notify-by-id notif-data))
     (response/ok "notification sent")))
-
 
 (defn routes [notif-comp]
   #{["/api/notifications/:id" :get (conj intercept/common-interceptors (partial http-get-notif notif-comp)) :route-name :get-notif]

--- a/server/src/spacon/components/http/notification.clj
+++ b/server/src/spacon/components/http/notification.clj
@@ -1,11 +1,22 @@
 (ns spacon.components.http.notification
   (:require [spacon.components.http.response :as response]
             [spacon.components.http.intercept :as intercept]
+            [clojure.tools.logging :as log]
             [spacon.components.notification.core :as notifapi]))
 
 (defn http-get-notif [notif-comp context]
   (let [id (Integer/parseInt (get-in context [:path-params :id]))]
     (response/ok (notifapi/find-notif-by-id notif-comp id))))
 
+(defn http-send-notif
+  "Send push notification json body"
+  [notif-comp request]
+  (let [notif-data (get-in request [:json-params])]
+    (notifapi/send->devices notif-data)
+    (response/ok "notification sent")))
+
+
 (defn routes [notif-comp]
-  #{["/api/notifications/:id" :get (conj intercept/common-interceptors (partial http-get-notif notif-comp)) :route-name :get-notif]})
+  #{["/api/notifications/:id" :get (conj intercept/common-interceptors (partial http-get-notif notif-comp)) :route-name :get-notif]
+    ["/api/notifications" :post (conj intercept/common-interceptors (partial http-send-notif notif-comp)) :route-name :send-notif]})
+

--- a/server/src/spacon/components/http/notification.clj
+++ b/server/src/spacon/components/http/notification.clj
@@ -1,7 +1,8 @@
 (ns spacon.components.http.notification
   (:require [spacon.components.http.response :as response]
             [spacon.components.http.intercept :as intercept]
-            [clojure.tools.logging :as log]
+            [clojure.spec :as s]
+            [spacon.specs.notification]
             [spacon.components.notification.core :as notifapi]))
 
 (defn http-get-notif [notif-comp context]
@@ -12,10 +13,14 @@
   "Send push notification, if :to is present just sent to device if not send to all devices"
   [notif-comp request]
   (let [notif-data (get-in request [:json-params])]
-    (if (nil? (:to notif-data))
-      (notifapi/notify notif-data)
-      (notifapi/notify-by-id notif-data))
-    (response/ok "notification sent")))
+    (if (s/valid? :spacon.specs.notification/notify-spec notif-data)
+      (do
+        (if (nil? (:to notif-data))
+          (notifapi/notify notif-data)
+          (notifapi/notify-by-id notif-data))
+        (response/ok "success"))
+      (let [err  (s/explain-str :spacon.specs.notification/notify-spec notif-data)]
+        (response/error err)))))
 
 (defn routes [notif-comp]
   #{["/api/notifications/:id" :get (conj intercept/common-interceptors (partial http-get-notif notif-comp)) :route-name :get-notif]

--- a/server/src/spacon/specs/notification.clj
+++ b/server/src/spacon/specs/notification.clj
@@ -1,0 +1,30 @@
+;; Copyright 2016-2017 Boundless, http://boundlessgeo.com
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns spacon.specs.notification
+  (:require [clojure.spec :as s]
+            [clojure.test.check.generators :as gen]))
+
+(def non-empty-string (s/with-gen
+                        (s/and string? #(> (count %) 0))
+                        #(gen/fmap identity gen/string-alphanumeric)))
+
+;;; specs about push notification data
+(s/def :n/title non-empty-string)
+(s/def :n/body non-empty-string)
+(s/def :n/notification (s/keys :req-un [:n/title :n/body]))
+(s/def ::to non-empty-string)
+
+(s/def ::notify-spec (s/keys :req-un [:n/notification]
+                             :opt-un [::to]))


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
UMC-33

## Description
Adds an endpoint to send Firebase push notification.  The endpoint supports sending to all devices or to a single device.  The difference is determined by the post body

`POST  /api/notification`

**All devices**
`{ "notification": {
    "title": "Some title",
    "body": "Some message"
  }
}`

**Single device**
`{ "notification": {
    "title": "Some title",
    "body": "Some message"
  },
  "to": "b05b4089-f8c1-43dc-8e65-8d017409a168"
}`

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

```sh
git fetch --all
git checkout <feature_branch> 
npm test
```

@boundlessgeo/spatial-connect